### PR TITLE
Added a default capstyle for boxplot median lines

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -4117,6 +4117,11 @@ class Axes(_AxesBase):
         if zorder is None:
             zorder = mlines.Line2D.zorder
 
+        # Set the default capstyle to "butt" to prevent
+        # visual overlap between the boxplot and median line
+        if medianprops.get('solid_capstyle') is None or medianprops.get('solid_capstyle', None) is None:
+            medianprops['solid_capstyle'] = 'butt'
+        # draw the median line below the boxplot for clarity
         zdelta = 0.1
 
         def merge_kw_rc(subkey, explicit, zdelta=0, usemarker=True):

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -3367,6 +3367,13 @@ def test_boxplot_zorder():
     assert ax.boxplot(x, zorder=10)['boxes'][0].get_zorder() == 10
 
 
+@check_figures_equal()
+def test_boxplot_median_bound(fig_test, fig_ref):
+    test_data = np.arange(3)
+    fig_test.subplots().boxplot(test_data,  medianprops={"linewidth": 10})
+    fig_ref.subplots().boxplot(test_data, medianprops={**{"linewidth": 10}, "solid_capstyle": "butt"})
+
+
 def test_boxplot_marker_behavior():
     plt.rcParams['lines.marker'] = 's'
     plt.rcParams['boxplot.flierprops.marker'] = 'o'


### PR DESCRIPTION
## PR Summary
Set the default capstyle for boxplot median lines to the 'butt' to prevent overlapping bug

## PR Checklist
- [x] Make sure the code runs
- [x] Make sure it doesn't hinder any other code

**Documentation and Tests**
- [x] Code Review and Tested Prior to Merge
- [x] Well documented code